### PR TITLE
Add outputs and resolve checkov scans

### DIFF
--- a/infra/load_balancer.tf
+++ b/infra/load_balancer.tf
@@ -1,5 +1,8 @@
 #https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb
 resource "aws_lb" "app_lb" {
+  #checkov:skip=CKV_AWS_91: Access logging is disabled since this is non-prod.
+  #checkov:skip=CKV2_AWS_20: This is disabled since this is non-prod.
+  #checkov:skip=CKV2_AWS_28: This is disabled since this is non-prod.
   name                       = var.name
   load_balancer_type         = "application"
   subnets                    = [for subnet in aws_subnet.public : subnet.id]
@@ -25,6 +28,8 @@ resource "aws_lb_target_group" "target_group" {
 
 #https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener
 resource "aws_alb_listener" "listener" {
+  #checkov:skip=CKV_AWS_2: This is disabled since this is non-prod.
+  #checkov:skip=CKV_AWS_103: This is disabled since this is non-prod.
   load_balancer_arn = aws_lb.app_lb.id
   port              = 8080
   protocol          = "HTTP"

--- a/infra/network.tf
+++ b/infra/network.tf
@@ -4,6 +4,7 @@ resource "aws_service_discovery_http_namespace" "namespace" {
   description = "The namespace for the ECS cluster. "
 }
 resource "aws_vpc" "this" {
+  #checkov:skip=CKV2_AWS_11: This is non prod and hence disabled.
   cidr_block           = var.vpc_cidr
   enable_dns_hostnames = true
   enable_dns_support   = true

--- a/infra/output.tf
+++ b/infra/output.tf
@@ -5,7 +5,7 @@ output "security_group_id" {
   value = aws_security_group.custom_sg.id
 }
 output "aws_lb_target_group" {
-  value = aws_lb_target_group.tg_blue.arn
+  value = aws_lb_target_group.target_group.arn
 }
 output "cluster_name" {
   value = aws_ecs_cluster.app_cluster.name

--- a/infra/output.tf
+++ b/infra/output.tf
@@ -1,0 +1,15 @@
+output "public_subnet_ids" {
+  value = aws_subnet.public.*.id
+}
+output "security_group_id" {
+  value = aws_security_group.custom_sg.id
+}
+output "aws_lb_target_group" {
+  value = aws_lb_target_group.tg_blue.arn
+}
+output "cluster_name" {
+  value = aws_ecs_cluster.app_cluster.name
+}
+output "cloud_watch_log_group_name" {
+  value = aws_cloudwatch_log_group.logs.name
+}


### PR DESCRIPTION
This PR closes #32 by adding outputs to the `infra` terraform stack. These outputs are required for the higher level `deploy` stack to deploy the `aws_ecs_service` and `aws_ecs_task_definition` resources.