### PR TITLE
Converted resource reference

### DIFF
--- a/.github/workflows/app-ci-cd.yml
+++ b/.github/workflows/app-ci-cd.yml
@@ -121,12 +121,6 @@ jobs:
         role-to-assume: ${{ secrets.IAM_ROLE }}
         role-session-name: AWSSession
         aws-region: ${{ env.AWS_REGION }}
-    - name: Verify AWS CLI installation
-      run: aws --version
-    # Install jq for parsing JSON output from AWS CLI
-    - name: Install jq
-      run: sudo apt-get install -y jq
-
     # Install the latest version of Terraform CLI and configure the Terraform CLI configuration file with a Terraform Cloud user API token
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@v1

--- a/.github/workflows/app-ci-cd.yml
+++ b/.github/workflows/app-ci-cd.yml
@@ -236,7 +236,7 @@ jobs:
     # On push to "main", build or change infrastructure according to Terraform configuration files
     # Note: It is recommended to set up a required "strict" status check in your repository for "Terraform Cloud". See the documentation on "strict" required status checks for more information: https://help.github.com/en/github/administering-a-repository/types-of-required-status-checks
     - name: Terraform Apply
-      if: github.ref == 'refs/heads/main'
+      # if: github.ref == 'refs/heads/main'
       run: |
         terraform apply -auto-approve -input=false \
         -var="image_tag=${{ env.IMAGE_ID }}" 

--- a/.github/workflows/app-ci-cd.yml
+++ b/.github/workflows/app-ci-cd.yml
@@ -236,7 +236,7 @@ jobs:
     # On push to "main", build or change infrastructure according to Terraform configuration files
     # Note: It is recommended to set up a required "strict" status check in your repository for "Terraform Cloud". See the documentation on "strict" required status checks for more information: https://help.github.com/en/github/administering-a-repository/types-of-required-status-checks
     - name: Terraform Apply
-      # if: github.ref == 'refs/heads/main'
+      if: github.ref == 'refs/heads/main'
       run: |
         terraform apply -auto-approve -input=false \
         -var="image_tag=${{ env.IMAGE_ID }}" 

--- a/deploy/code_deploy_deployment.tf
+++ b/deploy/code_deploy_deployment.tf
@@ -104,7 +104,7 @@ resource "local_file" "code_deploy_sh" {
 
 resource "terraform_data" "trigger_code_deploy_deployment" {
   triggers_replace = local.script
-    provisioner "local-exec" {
+  provisioner "local-exec" {
     command     = "./code_deploy.sh"
     interpreter = ["/bin/bash", "-c"]
   }

--- a/deploy/code_deploy_deployment.tf
+++ b/deploy/code_deploy_deployment.tf
@@ -89,19 +89,7 @@ resource "local_file" "code_deploy_sh" {
   ]
 }
 
-# #Execute the code_deploy.sh file to run the AWS CodeDeploy deployment
-# #https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource
-# resource "null_resource" "code_deploy" {
-#   triggers = {
-#     script_content = local.script
-#   }
-#   provisioner "local-exec" {
-#     command     = "./code_deploy.sh"
-#     interpreter = ["/bin/bash", "-c"]
-#   }
-#   depends_on = [local_file.code_deploy_sh]
-# }
-
+#https://developer.hashicorp.com/terraform/language/resources/terraform-data
 resource "terraform_data" "trigger_code_deploy_deployment" {
   triggers_replace = local.script
   provisioner "local-exec" {

--- a/deploy/code_deploy_deployment.tf
+++ b/deploy/code_deploy_deployment.tf
@@ -89,13 +89,22 @@ resource "local_file" "code_deploy_sh" {
   ]
 }
 
-#Execute the code_deploy.sh file to run the AWS CodeDeploy deployment
-#https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource
-resource "null_resource" "code_deploy" {
-  triggers = {
-    script_content = local.script
-  }
-  provisioner "local-exec" {
+# #Execute the code_deploy.sh file to run the AWS CodeDeploy deployment
+# #https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource
+# resource "null_resource" "code_deploy" {
+#   triggers = {
+#     script_content = local.script
+#   }
+#   provisioner "local-exec" {
+#     command     = "./code_deploy.sh"
+#     interpreter = ["/bin/bash", "-c"]
+#   }
+#   depends_on = [local_file.code_deploy_sh]
+# }
+
+resource "terraform_data" "trigger_code_deploy_deployment" {
+  triggers_replace = local.script
+    provisioner "local-exec" {
     command     = "./code_deploy.sh"
     interpreter = ["/bin/bash", "-c"]
   }


### PR DESCRIPTION
The earlier code version referenced `null_resource`, which is not the recommended approach to manage the `provisioner "local-exec"`. A cleaner approach is to use the `terraform_data` resource. More info with the associated issue #103. This PR closes #103 .